### PR TITLE
Travis ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: android
+jdk:
+  - oraclejdk8
+android:
+  components:
+    - tools
+    - build-tools-22.0.1
+    - android-24
+    - extra-android-m2repository
+
+script:
+- ./gradlew aDebug

--- a/build.gradle
+++ b/build.gradle
@@ -180,10 +180,10 @@ subprojects {
                 }
 
                 bintray {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    user = properties.getProperty("bintray.user")
-                    key = properties.getProperty("bintray.apikey")
+                    // You should configure "bintray.user" and "bintray.apiKey" in the gradle.properties 
+					// that in gradle cache directory
+                    user = safeGetProperty("bintray.user")
+                    key = safeGetProperty("bintray.apikey")
 
                     publications = ['mavenJava']
                     publish = true    //是否发布
@@ -202,14 +202,13 @@ subprojects {
                             desc = project.pomDescription
                             gpg {
                                 sign = false    //是否GPG签名，可使用Gpg4win创建密钥文件
-                                passphrase = properties.getProperty("bintray.gpg.password")
-                                //GPG签名所用密钥
+								//GPG签名所用密钥
+                                passphrase = safeGetProperty("bintray.gpg.password")
                             }
                             mavenCentralSync {
                                 sync = false    //是否同步到Maven Central
-                                user = properties.getProperty("sonatype.user")    //sonatype用户名
-                                password = properties.getProperty("sonatype.password")
-                                //sonatype密码
+                                user = safeGetProperty("sonatype.user") //sonatype用户名
+                                password = safeGetProperty("sonatype.password")	//sonatype密码
                                 close = '1'
                             }
                         }
@@ -219,5 +218,9 @@ subprojects {
             }
         }
     }
+}
+
+String safeGetProperty(String key) {
+    hasProperty("key") ? getProperty("key") : ""
 }
 


### PR DESCRIPTION
该Pull Request为实现 [#46](https://github.com/gzu-liyujiang/AndroidPicker/issues/46)所提建议。

在合并该请求前，你需要在travis-ci.org开启该项目的构建，具体步骤可参考https://github.com/gzu-liyujiang/AndroidPicker/issues/46#issuecomment-247641823。
开启完成之后，带有.travis-ci.yml文件的分支才能触发travis-ci构建。

接下来，你可以把构建状态的图标加到README中，它在你登录travis-ci.org打开该项目后的项目名称右边。

另外，像`bintray.user`之类的变量，我在build.gradle中看到你似乎是通过项目中的local.properties来配置的。像这类私有变量，且又是在其他项目也通用的，一般建议配置在gradle用户目录的`gradle.properties`（没有可新建）中。如果没有配置过`GRADLE_USER_HOME`环境变量，gradle用户目录默认是在系统用户目录下的.gradle，如使用linux的话是在`~/.gradle/`。local.properties用于配置因机器环境不同而值不同的变量，如sdk或ndk的位置等。在	`562e012`中，我已经改去获取发布到jcenter或maven时所需的变量的方式，你若通过此PR，需要在自己的~/.gradle/gradle.properties文件中配置相关变量，它会在gradle运行时作为环境变量被加载，因此可以直接通过`getProperty("key")`来获取。

使用travis-ci可以确认一个项目在不是自己的电脑上是否也能构建成功，也可以测试其他人提交上来的分支是否能通过构建。